### PR TITLE
Add cfg(test) around all testing paths

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -1,8 +1,11 @@
 #[cfg(feature = "driver")]
 use crate::{
-    driver::{retry::Retry, test_config::*, CryptoMode, DecodeMode, MixMode},
+    driver::{retry::Retry, CryptoMode, DecodeMode, MixMode},
     input::codecs::*,
 };
+
+#[cfg(test)]
+use crate::driver::test_config::*;
 
 #[cfg(feature = "driver")]
 use symphonia::core::{codecs::CodecRegistry, probe::Probe};
@@ -111,9 +114,11 @@ pub struct Config {
 
     // Test only attributes
     #[cfg(feature = "driver")]
+    #[cfg(test)]
     /// Test config to offer precise control over mixing tick rate/count.
     pub(crate) tick_style: TickStyle,
     #[cfg(feature = "driver")]
+    #[cfg(test)]
     /// If set, skip connection and encryption steps.
     pub(crate) override_connection: Option<OutputMode>,
 }
@@ -140,8 +145,10 @@ impl Default for Config {
             #[cfg(feature = "driver")]
             format_registry: &PROBE,
             #[cfg(feature = "driver")]
+            #[cfg(test)]
             tick_style: TickStyle::Timed,
             #[cfg(feature = "driver")]
+            #[cfg(test)]
             override_connection: None,
         }
     }

--- a/src/driver/mod.rs
+++ b/src/driver/mod.rs
@@ -17,6 +17,7 @@ mod decode_mode;
 mod mix_mode;
 pub mod retry;
 pub(crate) mod tasks;
+#[cfg(test)]
 pub(crate) mod test_config;
 
 use connection::error::{Error, Result};

--- a/src/driver/tasks/mixer/mod.rs
+++ b/src/driver/tasks/mixer/mod.rs
@@ -13,10 +13,7 @@ pub use track::*;
 use super::{disposal, error::Result, message::*};
 use crate::{
     constants::*,
-    driver::{
-        test_config::{OutputMessage, OutputMode, TickStyle},
-        MixMode,
-    },
+    driver::MixMode,
     events::EventStore,
     input::{Input, Parsed},
     tracks::{Action, LoopState, PlayError, PlayMode, TrackCommand, TrackHandle, TrackState, View},
@@ -31,7 +28,6 @@ use audiopus::{
 use discortp::{
     rtp::{MutableRtpPacket, RtpPacket},
     MutablePacket,
-    Packet,
 };
 use flume::{Receiver, Sender, TryRecvError};
 use rand::random;
@@ -53,6 +49,9 @@ use symphonia_core::{
 use tokio::runtime::Handle;
 use tracing::{debug, error, instrument, warn};
 use xsalsa20poly1305::TAG_SIZE;
+
+#[cfg(test)]
+use crate::driver::test_config::{OutputMessage, OutputMode, TickStyle};
 
 pub struct Mixer {
     pub bitrate: Bitrate,
@@ -181,8 +180,13 @@ impl Mixer {
         let mut events_failure = false;
         let mut conn_failure = false;
 
+        #[cfg(test)]
+        let ignore_check = self.config.override_connection.is_some();
+        #[cfg(not(test))]
+        let ignore_check = false;
+
         'runner: loop {
-            if self.conn_active.is_some() || self.config.override_connection.is_some() {
+            if self.conn_active.is_some() || ignore_check {
                 loop {
                     match self.mix_rx.try_recv() {
                         Ok(m) => {
@@ -207,7 +211,7 @@ impl Mixer {
 
                 // The above action may have invalidated the connection; need to re-check!
                 // Also, if we're in a test mode we should unconditionally run packet mixing code.
-                if self.conn_active.is_some() || self.config.override_connection.is_some() {
+                if self.conn_active.is_some() || ignore_check {
                     if let Err(e) = self.cycle().and_then(|_| self.audio_commands_events()) {
                         events_failure |= e.should_trigger_interconnect_rebuild();
                         conn_failure |= e.should_trigger_connect();
@@ -555,38 +559,46 @@ impl Mixer {
         Ok(())
     }
 
+    #[cfg(test)]
+    fn _march_deadline(&mut self) {
+        match &self.config.tick_style {
+            TickStyle::Timed => {
+                std::thread::sleep(self.deadline.saturating_duration_since(Instant::now()));
+                self.deadline += TIMESTEP_LENGTH;
+            },
+            TickStyle::UntimedWithExecLimit(rx) => {
+                if self.remaining_loops.is_none() {
+                    if let Ok(new_val) = rx.recv() {
+                        self.remaining_loops = Some(new_val.wrapping_sub(1));
+                    }
+                }
+
+                if let Some(cnt) = self.remaining_loops.as_mut() {
+                    if *cnt == 0 {
+                        self.remaining_loops = None;
+                    } else {
+                        *cnt = cnt.wrapping_sub(1);
+                    }
+                }
+            },
+        }
+    }
+
+    #[cfg(not(test))]
+    #[inline(always)]
+    #[allow(clippy::inline_always)] // Justified, this is a very very hot path
+    fn _march_deadline(&mut self) {
+        std::thread::sleep(self.deadline.saturating_duration_since(Instant::now()));
+        self.deadline += TIMESTEP_LENGTH;
+    }
+
     #[inline]
     fn march_deadline(&mut self) {
         if self.skip_sleep {
             return;
         }
 
-        // Timed is the usual, default case.
-        // The others exist for end-to-end testing.
-        match &self.config.tick_style {
-            TickStyle::Timed => {
-                std::thread::sleep(self.deadline.saturating_duration_since(Instant::now()));
-                self.deadline += TIMESTEP_LENGTH;
-            },
-            TickStyle::UntimedWithExecLimit(_rx) => {
-                #[cfg(test)]
-                {
-                    if self.remaining_loops.is_none() {
-                        if let Ok(new_val) = _rx.recv() {
-                            self.remaining_loops = Some(new_val.wrapping_sub(1));
-                        }
-                    }
-
-                    if let Some(cnt) = self.remaining_loops.as_mut() {
-                        if *cnt == 0 {
-                            self.remaining_loops = None;
-                        } else {
-                            *cnt = cnt.wrapping_sub(1);
-                        }
-                    }
-                }
-            },
-        }
+        self._march_deadline();
     }
 
     pub fn cycle(&mut self) -> Result<()> {
@@ -638,6 +650,7 @@ impl Mixer {
 
                 self.march_deadline();
 
+                #[cfg(test)]
                 match &self.config.override_connection {
                     Some(OutputMode::Raw(tx)) =>
                         drop(tx.send(crate::driver::test_config::TickMessage::NoEl)),
@@ -675,6 +688,8 @@ impl Mixer {
         // Wait till the right time to send this packet:
         // usually a 20ms tick, in test modes this is either a finite number of runs or user input.
         self.march_deadline();
+
+        #[cfg(test)]
         if let Some(OutputMode::Raw(tx)) = &self.config.override_connection {
             let msg = match mix_len {
                 MixType::Passthrough(len) if len == SILENT_FRAME.len() => OutputMessage::Silent,
@@ -697,6 +712,9 @@ impl Mixer {
         } else {
             self.prep_and_send_packet(&mix_buffer, mix_len)?;
         }
+
+        #[cfg(not(test))]
+        self.prep_and_send_packet(&mix_buffer, mix_len)?;
 
         if matches!(mix_len, MixType::MixedPcm(a) if a > 0) {
             for plane in self.symph_mix.planes_mut().planes() {
@@ -743,6 +761,7 @@ impl Mixer {
                 .write_packet_nonce(&mut rtp, TAG_SIZE + payload_len);
 
             // Packet encryption ignored in test modes.
+            #[cfg(test)]
             if self.config.override_connection.is_none() {
                 conn.crypto_state.kind().encrypt_in_place(
                     &mut rtp,
@@ -754,10 +773,17 @@ impl Mixer {
             RtpPacket::minimum_packet_size() + final_payload_size
         };
 
+        #[cfg(test)]
         if let Some(OutputMode::Rtp(tx)) = &self.config.override_connection {
             // Test mode: send unencrypted (compressed) packets to local receiver.
             drop(tx.send(self.packet[..index].to_vec().into()));
         } else {
+            conn.udp_tx
+                .send(UdpTxMessage::Packet(self.packet[..index].to_vec()))?;
+        }
+
+        #[cfg(not(test))]
+        {
             // Normal operation: send encrypted payload to UDP Tx task.
 
             // TODO: This is dog slow, don't do this.

--- a/src/driver/tasks/mixer/mod.rs
+++ b/src/driver/tasks/mixer/mod.rs
@@ -52,7 +52,8 @@ use xsalsa20poly1305::TAG_SIZE;
 
 #[cfg(test)]
 use crate::driver::test_config::{OutputMessage, OutputMode, TickStyle};
-
+#[cfg(test)]
+use discortp::Packet as _;
 pub struct Mixer {
     pub bitrate: Bitrate,
     pub config: Arc<Config>,

--- a/src/driver/test_config.rs
+++ b/src/driver/test_config.rs
@@ -2,7 +2,6 @@
 
 use flume::{Receiver, Sender};
 
-#[cfg(test)]
 use crate::{
     tracks::{PlayMode, TrackHandle},
     Event,
@@ -10,7 +9,6 @@ use crate::{
     EventHandler,
     TrackEvent,
 };
-#[cfg(test)]
 use std::time::Duration;
 
 #[allow(dead_code)]
@@ -70,7 +68,6 @@ impl<T> From<T> for TickMessage<T> {
     }
 }
 
-#[cfg(test)]
 impl From<TickMessage<OutputMessage>> for OutputPacket {
     fn from(val: TickMessage<OutputMessage>) -> Self {
         match val {
@@ -80,7 +77,6 @@ impl From<TickMessage<OutputMessage>> for OutputPacket {
     }
 }
 
-#[cfg(test)]
 impl From<TickMessage<Vec<u8>>> for OutputPacket {
     fn from(val: TickMessage<Vec<u8>>) -> Self {
         match val {
@@ -90,7 +86,6 @@ impl From<TickMessage<Vec<u8>>> for OutputPacket {
     }
 }
 
-#[cfg(test)]
 #[derive(Clone, Debug, PartialEq)]
 pub enum OutputPacket {
     Raw(OutputMessage),
@@ -98,7 +93,6 @@ pub enum OutputPacket {
     Empty,
 }
 
-#[cfg(test)]
 impl OutputPacket {
     pub fn raw(&self) -> Option<&OutputMessage> {
         if let Self::Raw(o) = self {
@@ -109,21 +103,18 @@ impl OutputPacket {
     }
 }
 
-#[cfg(test)]
 #[derive(Clone, Debug)]
 pub enum OutputReceiver {
     Raw(Receiver<TickMessage<OutputMessage>>),
     Rtp(Receiver<TickMessage<Vec<u8>>>),
 }
 
-#[cfg(test)]
 #[derive(Clone)]
 pub struct DriverTestHandle {
     pub rx: OutputReceiver,
     pub tx: Sender<u64>,
 }
 
-#[cfg(test)]
 impl DriverTestHandle {
     pub fn recv(&self) -> OutputPacket {
         match &self.rx {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -107,9 +107,6 @@ pub use serenity_voice_model as model;
 #[cfg(feature = "driver")]
 pub use typemap_rev as typemap;
 
-#[cfg(test)]
-use utils as test_utils;
-
 #[cfg(feature = "driver")]
 pub use crate::{
     driver::Driver,

--- a/src/tracks/queue.rs
+++ b/src/tracks/queue.rs
@@ -359,7 +359,6 @@ impl TrackQueueCore {
 
 #[cfg(all(test, feature = "builtin-queue"))]
 mod tests {
-    use super::*;
     use crate::{
         driver::Driver,
         input::{File, HttpRequest},


### PR DESCRIPTION
This saves a good amount of performance in march_deadline and probably other places, and possibly improves compile time.