### PR TITLE
Remove unnecessary chrono dep

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -90,6 +90,7 @@ optional = true
 version = "0.7"
 
 [dependencies.serde-aux]
+default-features = false
 optional = true
 version = "3"
 


### PR DESCRIPTION
Chrono was added as a dep via serde-aux, which I noticed when doing a `cargo update` on my bot which doesn't depend on chrono for good reason. This removes it by disabling the default `chrono` feature of `serde-aux`